### PR TITLE
introduce branch coverage metric for llvm source-based coverage

### DIFF
--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -76,7 +76,9 @@ def measure_main(experiment_config):
     max_total_time = experiment_config['max_total_time']
     measurers_cpus = experiment_config['measurers_cpus']
     runners_cpus = experiment_config['runners_cpus']
-    measure_loop(experiment, max_total_time, measurers_cpus, runners_cpus)
+    use_branch_coverage = experiment_config['use_branch_coverage']
+    measure_loop(experiment, max_total_time, measurers_cpus, runners_cpus,
+                 use_branch_coverage)
 
     # Clean up resources.
     gc.collect()
@@ -97,7 +99,8 @@ def _process_init(cores_queue):
 def measure_loop(experiment: str,
                  max_total_time: int,
                  measurers_cpus=None,
-                 runners_cpus=None):
+                 runners_cpus=None,
+                 use_branch_coverage=False):
     """Continuously measure trials for |experiment|."""
     logger.info('Start measure_loop.')
 
@@ -126,7 +129,8 @@ def measure_loop(experiment: str,
                 # races.
                 all_trials_ended = scheduler.all_trials_ended(experiment)
 
-                if not measure_all_trials(experiment, max_total_time, pool, q):
+                if not measure_all_trials(experiment, max_total_time, pool, q,
+                                          use_branch_coverage):
                     # We didn't measure any trials.
                     if all_trials_ended:
                         # There are no trials producing snapshots to measure.
@@ -141,7 +145,12 @@ def measure_loop(experiment: str,
     logger.info('Finished measure loop.')
 
 
-def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  # pylint: disable=invalid-name
+def measure_all_trials(
+        experiment: str,
+        max_total_time: int,
+        pool,
+        q,
+        use_branch_coverage: bool = False) -> bool:  # pylint: disable=invalid-name
     """Get coverage data (with coverage runs) for all active trials. Note that
     this should not be called unless multiprocessing.set_start_method('spawn')
     was called first. Otherwise it will use fork which breaks logging."""
@@ -158,7 +167,7 @@ def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  
         return False
 
     measure_trial_coverage_args = [
-        (unmeasured_snapshot, max_cycle, q)
+        (unmeasured_snapshot, max_cycle, q, use_branch_coverage)
         for unmeasured_snapshot in unmeasured_snapshots
     ]
 
@@ -356,8 +365,12 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
     UNIT_BLACKLIST = collections.defaultdict(set)
 
-    def __init__(self, fuzzer: str, benchmark: str, trial_num: int,
-                 trial_logger: logs.Logger):
+    def __init__(self,
+                 fuzzer: str,
+                 benchmark: str,
+                 trial_num: int,
+                 trial_logger: logs.Logger,
+                 use_branch_coverage: bool = False):
         super().__init__(fuzzer, benchmark, trial_num)
         self.logger = trial_logger
         self.corpus_dir = os.path.join(self.measurement_dir, 'corpus')
@@ -386,6 +399,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         # Store the coverage information in json form.
         self.cov_summary_file = os.path.join(self.report_dir,
                                              'cov_summary.json')
+
+        # Whether to use branch coverage or region coverage (default)
+        self.use_branch_coverage = use_branch_coverage
 
     def get_profraw_files(self):
         """Return generated profraw files."""
@@ -438,7 +454,10 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
                 self.cov_summary_file)
             coverage_data = coverage_info["data"][0]
             summary_data = coverage_data["totals"]
-            regions_coverage_data = summary_data["regions"]
+            if self.use_branch_coverage:
+                regions_coverage_data = summary_data["branches"]
+            else:
+                regions_coverage_data = summary_data["regions"]
             regions_covered = regions_coverage_data["covered"]
             return regions_covered
         except Exception:  # pylint: disable=broad-except
@@ -612,8 +631,10 @@ def get_fuzzer_stats(stats_filestore_path):
 
 
 def measure_trial_coverage(  # pylint: disable=invalid-name
-        measure_req, max_cycle: int,
-        q: multiprocessing.Queue) -> models.Snapshot:
+        measure_req,
+        max_cycle: int,
+        q: multiprocessing.Queue,
+        use_branch_coverage: bool = False) -> models.Snapshot:
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()
@@ -624,7 +645,8 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
         try:
             snapshot = measure_snapshot_coverage(measure_req.fuzzer,
                                                  measure_req.benchmark,
-                                                 measure_req.trial_id, cycle)
+                                                 measure_req.trial_id, cycle,
+                                                 use_branch_coverage)
             if not snapshot:
                 break
             q.put(snapshot)
@@ -640,8 +662,11 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
 
 
 def measure_snapshot_coverage(  # pylint: disable=too-many-locals
-        fuzzer: str, benchmark: str, trial_num: int,
-        cycle: int) -> models.Snapshot:
+        fuzzer: str,
+        benchmark: str,
+        trial_num: int,
+        cycle: int,
+        use_branch_coverage: bool = False) -> models.Snapshot:
     """Measure coverage of the snapshot for |cycle| for |trial_num| of |fuzzer|
     and |benchmark|."""
     snapshot_logger = logs.Logger('measurer',
@@ -652,7 +677,7 @@ def measure_snapshot_coverage(  # pylint: disable=too-many-locals
                                       'cycle': str(cycle),
                                   })
     snapshot_measurer = SnapshotMeasurer(fuzzer, benchmark, trial_num,
-                                         snapshot_logger)
+                                         snapshot_logger, use_branch_coverage)
 
     measuring_start_time = time.time()
     snapshot_logger.info('Measuring cycle: %d.', cycle)

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -178,7 +178,7 @@ def test_measure_trial_coverage(mocked_measure_snapshot_coverage, mocked_queue,
     measure_manager.measure_trial_coverage(measure_request, max_cycle,
                                            mocked_queue())
     expected_calls = [
-        mock.call(FUZZER, BENCHMARK, TRIAL_NUM, cycle)
+        mock.call(FUZZER, BENCHMARK, TRIAL_NUM, cycle, False)
         for cycle in range(min_cycle, max_cycle + 1)
     ]
     assert mocked_measure_snapshot_coverage.call_args_list == expected_calls

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -219,7 +219,8 @@ def start_experiment(  # pylint: disable=too-many-arguments
         allow_uncommitted_changes=False,
         concurrent_builds=None,
         measurers_cpus=None,
-        runners_cpus=None):
+        runners_cpus=None,
+        use_branch_coverage=False):
     """Start a fuzzer benchmarking experiment."""
     if not allow_uncommitted_changes:
         check_no_uncommitted_changes()
@@ -234,6 +235,7 @@ def start_experiment(  # pylint: disable=too-many-arguments
     config['git_hash'] = get_git_hash()
     config['no_seeds'] = no_seeds
     config['no_dictionaries'] = no_dictionaries
+    config['use_branch_coverage'] = use_branch_coverage
     config['oss_fuzz_corpus'] = oss_fuzz_corpus
     config['description'] = description
     config['concurrent_builds'] = concurrent_builds
@@ -543,6 +545,12 @@ def main():
                         required=False,
                         default=False,
                         action='store_true')
+    parser.add_argument('-bc',
+                        '--use-branch-coverage',
+                        help='Use branch coverage instead of region coverage.',
+                        required=False,
+                        default=False,
+                        action='store_true')
     parser.add_argument('-a',
                         '--allow-uncommitted-changes',
                         help='Skip check that no uncommited changes made.',
@@ -596,7 +604,8 @@ def main():
                      allow_uncommitted_changes=args.allow_uncommitted_changes,
                      concurrent_builds=concurrent_builds,
                      measurers_cpus=measurers_cpus,
-                     runners_cpus=runners_cpus)
+                     runners_cpus=runners_cpus,
+                     use_branch_coverage=args.use_branch_coverage)
     return 0
 
 


### PR DESCRIPTION
This PR add a support for branch coverage metric offered by [Source-based Code Coverage](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#branch-regions). This branch condition coverage is a newly supported metric that offers more granular information. 

To port this feature to fuzzbench, we simply need to change the field from `regions` to `branches` when reading covearge json generated by llvm. 

The example content of the exported coverage json
```
{
  "data": [
    {
      "files": [
        {
          "branches": [
            [807, 9, 807, 52, 0, 0, 0, 0, 4],
            [809, 9, 809, 21, 0, 0, 0, 0, 4],
            [809, 25, 809, 37, 0, 0, 0, 0, 4],
            [815, 7, 815, 19, 0, 0, 0, 0, 4],
            [815, 23, 815, 35, 0, 0, 0, 0, 4],
            [818, 9, 818, 53, 0, 0, 0, 0, 4],
            [820, 9, 820, 21, 0, 0, 0, 0, 4],
            [820, 25, 820, 37, 0, 0, 0, 0, 4],
            [826, 7, 826, 19, 0, 0, 0, 0, 4],
            [516, 29, 516, 40, 0, 0, 0, 0, 4],
            [526, 27, 526, 38, 0, 0, 0, 0, 4],
            [527, 29, 527, 40, 0, 0, 0, 0, 4]
          ],
          "filename": "/src/libjpeg-turbo/transupp.c",
          "segments": [
            [34, 39, 0, true, true, false],
            [34, 46, 0, false, false, false],
            [35, 39, 0, true, true, false],
            [35, 46, 0, false, false, false],
            [97, 1, 0, true, true, false],
            [102, 1, 0, false, true, false],
            [105, 6, 0, true, false, false],
            [106, 16, 0, true, true, false],
            [106, 44, 0, true, false, false],
            [1543, 3, 0, true, true, false],
            [1544, 9, 0, true, true, false],
            [1544, 47, 0, true, false, false],
            [1620, 43, 0, true, false, false],
            [1621, 9, 0, true, true, false],
            [1621, 18, 0, true, true, false],
            [1621, 43, 0, true, false, false],
            [1622, 7, 0, true, true, false],
            [1622, 15, 0, true, false, true],
            [1623, 5, 0, true, true, false],
            [1625, 4, 0, true, false, false],
            [1626, 2, 0, false, false, false]
          ],
          "summary": {
            "branches": {
              "count": 552,
              "covered": 0,
              "notcovered": 552,
              "percent": 0
            },
            "functions": { "count": 21, "covered": 0, "percent": 0 },
            "instantiations": { "count": 21, "covered": 0, "percent": 0 },
            "lines": { "count": 1064, "covered": 0, "percent": 0 },
            "regions": {
              "count": 917,
              "covered": 0,
              "notcovered": 917,
              "percent": 0
            }
          }
        },
        {
          "branches": [],
          "filename": "/src/libjpeg-turbo/transupp.h",
          "segments": [
            [184, 49, 0, true, true, false],
            [184, 77, 0, false, false, false]
          ],
          "summary": {
            "branches": {
              "count": 0,
              "covered": 0,
              "notcovered": 0,
              "percent": 0
            },
            "functions": { "count": 0, "covered": 0, "percent": 0 },
            "instantiations": { "count": 0, "covered": 0, "percent": 0 },
            "lines": { "count": 0, "covered": 0, "percent": 0 },
            "regions": {
              "count": 0,
              "covered": 0,
              "notcovered": 0,
              "percent": 0
            }
          }
        },
        {
          "branches": [
            [555, 5, 555, 24, 0, 1, 0, 0, 4],

            [1527, 26, 1527, 32, 0, 0, 0, 0, 4],
            [1531, 4, 1531, 10, 0, 0, 0, 0, 4],
            [1535, 11, 1535, 14, 0, 0, 0, 0, 4],
            [1537, 6, 1537, 36, 0, 0, 0, 0, 4]
          ],
          "filename": "/src/libjpeg-turbo/turbojpeg.c",
          "segments": [
            [50, 19, 0, true, true, false],
            [86, 2, 0, false, false, false],
            [109, 15, 10, true, true, false],
            [1815, 19, 0, true, false, false],
            [1816, 6, 0, true, true, false],
            [1816, 20, 0, true, false, false],
            [1816, 24, 0, true, true, false],
            [1816, 39, 0, true, false, false],
            [1817, 4, 0, true, true, false],
            [1817, 9, 0, true, false, false],
            [1819, 5, 0, true, true, false],
            [1819, 8, 0, true, true, false],
            [1819, 13, 0, true, false, false],
            [1820, 3, 0, true, true, false],
            [2187, 2, 0, false, false, false]
          ],
          "summary": {
            "branches": {
              "count": 910,
              "covered": 94,
              "notcovered": 816,
              "percent": 10.329670329670328
            },
            "functions": {
              "count": 46,
              "covered": 8,
              "percent": 17.391304347826086
            },
            "instantiations": {
              "count": 46,
              "covered": 8,
              "percent": 17.391304347826086
            },
            "lines": {
              "count": 1333,
              "covered": 168,
              "percent": 12.603150787696924
            },
            "regions": {
              "count": 1496,
              "covered": 179,
              "notcovered": 1317,
              "percent": 11.965240641711231
            }
          }
        },
        {
          "branches": [],
          "filename": "/src/libjpeg-turbo/turbojpeg.h",
          "segments": [
            [470, 25, 0, true, true, false],
            [470, 26, 0, false, false, false],
            [477, 25, 0, true, true, false],
            [477, 27, 0, false, false, false],
            [1497, 23, 0, true, true, false],
            [1497, 25, 0, false, false, false],
            [1500, 16, 0, true, true, false],
            [1500, 19, 0, false, false, false]
          ],
          "summary": {
            "branches": {
              "count": 0,
              "covered": 0,
              "notcovered": 0,
              "percent": 0
            },
            "functions": { "count": 0, "covered": 0, "percent": 0 },
            "instantiations": { "count": 0, "covered": 0, "percent": 0 },
            "lines": { "count": 0, "covered": 0, "percent": 0 },
            "regions": {
              "count": 0,
              "covered": 0,
              "notcovered": 0,
              "percent": 0
            }
          }
        },
        {
          "branches": [
            [33, 9, 33, 17, 0, 1, 0, 0, 4],
            [33, 21, 33, 31, 0, 1, 0, 0, 4],
            [33, 35, 33, 46, 0, 1, 0, 0, 4],
            [33, 50, 33, 90, 0, 1, 0, 0, 4]
          ],
          "filename": "/src/libjpeg_turbo_fuzzer.cc",
          "segments": [
            [23, 73, 1, true, true, false],
            [25, 1, 0, false, true, false],
            [25, 1, 1, true, false, false],
            [29, 1, 0, false, true, false],
            [32, 45, 1, true, false, false],
            [33, 9, 1, true, true, false],
            [33, 17, 1, true, false, false],
            [33, 21, 1, true, true, false],
            [33, 31, 1, true, false, false],
            [33, 35, 1, true, true, false],
            [33, 46, 1, true, false, false],
            [33, 50, 1, true, true, false],
            [33, 90, 1, true, false, false],
            [33, 91, 0, true, false, true],
            [33, 92, 0, true, true, false],
            [36, 6, 1, true, false, true],
            [37, 1, 0, false, true, false],
            [37, 1, 1, true, false, true],
            [38, 5, 1, true, true, false],
            [41, 1, 0, false, true, false],
            [41, 1, 1, true, false, false],
            [43, 1, 0, false, true, false],
            [43, 1, 1, true, false, false],
            [45, 2, 0, false, false, false]
          ],
          "summary": {
            "branches": {
              "count": 8,
              "covered": 4,
              "notcovered": 4,
              "percent": 50
            },
            "functions": { "count": 1, "covered": 1, "percent": 100 },
            "instantiations": { "count": 1, "covered": 1, "percent": 100 },
            "lines": { "count": 15, "covered": 12, "percent": 80 },
            "regions": {
              "count": 10,
              "covered": 9,
              "notcovered": 1,
              "percent": 90
            }
          }
        }
      ],
      "functions": [
        {
          "branches": [
            [623, 7, 623, 26, 0, 0, 0, 0, 4],
            [630, 16, 630, 48, 0, 0, 0, 0, 4],
            [315, 15, 315, 45, 0, 0, 2, 0, 4],
            [316, 17, 316, 37, 0, 0, 2, 0, 4],
            [315, 15, 315, 45, 0, 0, 3, 0, 4],
            [316, 17, 316, 37, 0, 0, 3, 0, 4]
          ],
          "count": 0,
          "filenames": [
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jmorecfg.h",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jmorecfg.h"
          ],
          "name": "jchuff.c:emit_restart",
          "regions": [
            [620, 1, 636, 2, 0, 0, 0, 0],
            [315, 15, 315, 45, 0, 2, 0, 0],
            [316, 13, 317, 26, 0, 2, 0, 0],
            [316, 17, 316, 37, 0, 2, 0, 0],
            [317, 15, 317, 26, 0, 2, 0, 0],
            [314, 9, 317, 28, 0, 3, 0, 0],
            [315, 15, 315, 45, 0, 3, 0, 0],
            [316, 13, 317, 26, 0, 3, 0, 0],
            [316, 17, 316, 37, 0, 3, 0, 0],
            [317, 15, 317, 26, 0, 3, 0, 0],
            [248, 17, 248, 18, 0, 4, 0, 0]
          ]
        },
        {
          "branches": [
            [476, 10, 476, 23, 0, 0, 0, 0, 4],
            [434, 7, 434, 38, 0, 0, 1, 0, 4],
            [350, 7, 350, 16, 0, 0, 3, 0, 4],
            [442, 7, 442, 15, 0, 0, 4, 0, 4],
            [445, 12, 445, 21, 0, 0, 4, 0, 4],
            [451, 11, 451, 37, 0, 0, 4, 0, 4],
            [452, 13, 452, 33, 0, 0, 4, 0, 4],
            [59, 20, 59, 27, 0, 0, 8, 0, 4]
          ],
          "count": 0,
          "filenames": [
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jmorecfg.h",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jmorecfg.h",
            "/src/libjpeg-turbo/jchuff.c",
            "/src/libjpeg-turbo/jinclude.h",
            "/src/libjpeg-turbo/jmorecfg.h",
            "/src/libjpeg-turbo/jpeglib.h"
          ],
          "name": "jchuff.c:flush_bits",
          "regions": [
            [465, 1, 483, 2, 0, 0, 0, 0],
            [453, 7, 454, 6, 0, 4, 0, 0],
            [456, 8, 459, 4, 0, 4, 0, 0],
            [248, 17, 248, 18, 0, 5, 0, 0],
            [431, 17, 431, 31, 0, 6, 0, 0],
            [431, 18, 431, 26, 0, 6, 11, 1],
            [103, 27, 103, 34, 0, 7, 0, 0],
            [59, 19, 59, 36, 0, 8, 0, 0],
            [59, 28, 59, 31, 0, 8, 0, 0],
            [59, 32, 59, 35, 0, 8, 0, 0],
            [71, 33, 71, 92, 0, 9, 0, 0],
            [245, 17, 245, 18, 0, 10, 0, 0],
            [47, 29, 47, 31, 0, 11, 0, 0]
          ]
        }
      ],
      "totals": {
        "branches": {
          "count": 9384,
          "covered": 776,
          "notcovered": 8608,
          "percent": 8.2693947144075022
        },
        "functions": {
          "count": 538,
          "covered": 112,
          "percent": 20.817843866171003
        },
        "instantiations": {
          "count": 600,
          "covered": 112,
          "percent": 18.666666666666668
        },
        "lines": {
          "count": 17165,
          "covered": 2122,
          "percent": 12.362365278182349
        },
        "regions": {
          "count": 18486,
          "covered": 1761,
          "notcovered": 16725,
          "percent": 9.5261278805582599
        }
      }
    }
  ],
  "type": "llvm.coverage.json.export",
  "version": "2.0.1"
}
```