### PR TITLE
Add support for random seed corpus

### DIFF
--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -72,6 +72,12 @@ def get_oss_fuzz_corpora_filestore_path():
     return posixpath.join(get_experiment_filestore_path(), 'oss_fuzz_corpora')
 
 
+def get_random_seed_corpora_filestore_path():
+    """Returns path containing the user-provided seed corpora."""
+    return posixpath.join(get_experiment_filestore_path(),
+                          'random_seed_corpora')
+
+
 def get_dispatcher_instance_name(experiment: str) -> str:
     """Returns a dispatcher instance name for an experiment."""
     return 'd-%s' % experiment

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -46,6 +46,7 @@ docker run \
 -e NO_SEEDS={{no_seeds}} \
 -e NO_DICTIONARIES={{no_dictionaries}} \
 -e OSS_FUZZ_CORPUS={{oss_fuzz_corpus}} \
+-e RANDOM_SEED_CORPUS={{random_seed_corpus}} \
 -e DOCKER_REGISTRY={{docker_registry}} {% if not local_experiment %}-e CLOUD_PROJECT={{cloud_project}} -e CLOUD_COMPUTE_ZONE={{cloud_compute_zone}} {% endif %}\
 -e EXPERIMENT_FILESTORE={{experiment_filestore}} {% if local_experiment %}-v {{experiment_filestore}}:{{experiment_filestore}} {% endif %}\
 -e REPORT_FILESTORE={{report_filestore}} {% if local_experiment %}-v {{report_filestore}}:{{report_filestore}} {% endif %}\

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -46,7 +46,7 @@ docker run \
 -e NO_SEEDS={{no_seeds}} \
 -e NO_DICTIONARIES={{no_dictionaries}} \
 -e OSS_FUZZ_CORPUS={{oss_fuzz_corpus}} \
--e RANDOM_SEED_CORPUS={{random_seed_corpus}} \
+-e RANDOM_SEED_CORPUS_DIR={{random_seed_corpus_dir}} \
 -e DOCKER_REGISTRY={{docker_registry}} {% if not local_experiment %}-e CLOUD_PROJECT={{cloud_project}} -e CLOUD_COMPUTE_ZONE={{cloud_compute_zone}} {% endif %}\
 -e EXPERIMENT_FILESTORE={{experiment_filestore}} {% if local_experiment %}-v {{experiment_filestore}}:{{experiment_filestore}} {% endif %}\
 -e REPORT_FILESTORE={{report_filestore}} {% if local_experiment %}-v {{report_filestore}}:{{report_filestore}} {% endif %}\

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -188,7 +188,8 @@ def validate_and_pack_random_seed_corpus(random_seed_corpus, benchmarks):
                 raise ValidationError('No valid corpus files for "%s"' %
                                       benchmark)
 
-            benchmark_corpus_archive_path = os.path.join(zip_dir, f'{benchmark}.zip')
+            benchmark_corpus_archive_path = os.path.join(
+                zip_dir, f'{benchmark}.zip')
             with zipfile.ZipFile(benchmark_corpus_archive_path, 'w') as archive:
                 for filename in valid_corpus_files:
                     dir_name = os.path.dirname(filename)
@@ -668,11 +669,11 @@ def main():
 
     if args.random_seed_corpus:
         if args.no_seeds:
-            parser.error(
-                'You cannot start an experiment with no_seeds option if'
-                ' seeds location is provided you')
+            parser.error('Cannot enable options "random_seed_corpus" and '
+                         '"no_seeds" at the same time')
         if args.oss_fuzz_corpus:
-            parser.error('Cannot use seeds from multiple sources')
+            parser.error('Cannot enable options "random_seed_corpus" and '
+                         '"oss_fuzz_corpus" at the same time')
 
     start_experiment(args.experiment_name,
                      args.experiment_config,

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -596,7 +596,7 @@ def main():
     parser.add_argument('-rs',
                         '--random-seed-corpus',
                         help='Path to the random seed corpus',
-                        required=True)
+                        required=False)
 
     all_fuzzers = fuzzer_utils.get_fuzzer_names()
     parser.add_argument('-f',

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -391,7 +391,7 @@ def copy_resources_to_bucket(config_dir: str, config: Dict):
                 config['random_seed_corpus_dir'], f'{benchmark}.zip')
             filestore_utils.cp(
                 benchmark_corpus_archive_path,
-                experiment_utils.get_random_seed_corpora_filestore_path() + "/",
+                experiment_utils.get_random_seed_corpora_filestore_path() + '/',
                 recursive=True,
                 parallel=True)
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -168,7 +168,7 @@ def validate_and_pack_random_seed_corpus(random_seed_corpus, benchmarks):
                                       'benchmark "%s" does not exist.' %
                                       benchmark)
             if not os.path.isdir(benchmark_corpus_dir):
-                raise ValidationError('seed corpus of benchmark "%s" must be '
+                raise ValidationError('Seed corpus of benchmark "%s" must be '
                                       'a directory.' % benchmark)
             if not os.listdir(benchmark_corpus_dir):
                 raise ValidationError(
@@ -188,8 +188,8 @@ def validate_and_pack_random_seed_corpus(random_seed_corpus, benchmarks):
                 raise ValidationError('No valid corpus files for "%s"' %
                                       benchmark)
 
-            seed_zip_archive_path = os.path.join(zip_dir, f'{benchmark}.zip')
-            with zipfile.ZipFile(seed_zip_archive_path, 'w') as archive:
+            benchmark_corpus_archive_path = os.path.join(zip_dir, f'{benchmark}.zip')
+            with zipfile.ZipFile(benchmark_corpus_archive_path, 'w') as archive:
                 for filename in valid_corpus_files:
                     dir_name = os.path.dirname(filename)
                     archive.write(

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -27,6 +27,7 @@ import tarfile
 import threading
 import time
 import zipfile
+import random
 
 from common import benchmark_config
 from common import environment
@@ -115,6 +116,20 @@ def get_clusterfuzz_seed_corpus_path(fuzz_target_path):
     return seed_corpus_path if os.path.exists(seed_corpus_path) else None
 
 
+def _unpack_random_seed_corpus(corpus_directory):
+    "Unpack and randomply pick one input from the seed corpus provided by user"
+    # remove initial seed corpus
+    shutil.rmtree(corpus_directory)
+    os.mkdir(corpus_directory)
+    benchmark = environment.get('BENCHMARK')
+    corpus_archive_filename = posixpath.join(
+        experiment_utils.get_random_seed_corpora_filestore_path(),
+        f'{benchmark}.zip')
+    with zipfile.ZipFile(corpus_archive_filename) as zip_file:
+        selected_file = random.choice(zip_file.infolist())
+        zip_file.extract(selected_file, corpus_directory)
+
+
 def _unpack_clusterfuzz_seed_corpus(fuzz_target_path, corpus_directory):
     """If a clusterfuzz seed corpus archive is available, unpack it into the
     corpus directory if it exists. Copied from unpack_seed_corpus in
@@ -172,7 +187,10 @@ def run_fuzzer(max_total_time, log_filename):
         logs.error('Fuzz target binary not found.')
         return
 
-    _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)
+    if environment.get('RANDOM_SEED_CORPUS'):
+        _unpack_random_seed_corpus(input_corpus)
+    else:
+        _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)
     _clean_seed_corpus(input_corpus)
 
     if max_total_time is None:

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -187,7 +187,7 @@ def run_fuzzer(max_total_time, log_filename):
         logs.error('Fuzz target binary not found.')
         return
 
-    if environment.get('RANDOM_SEED_CORPUS'):
+    if environment.get('RANDOM_SEED_CORPUS_DIR'):
         _unpack_random_seed_corpus(input_corpus)
     else:
         _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -717,7 +717,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
         'oss_fuzz_corpus': experiment_config['oss_fuzz_corpus'],
         'num_cpu_cores': experiment_config['runner_num_cpu_cores'],
         'cpuset': CPUSET,
-        'random_seed_corpus': experiment_config['random_seed_corpus'],
+        'random_seed_corpus_dir': experiment_config['random_seed_corpus_dir'],
     }
 
     if not local_experiment:

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -717,6 +717,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
         'oss_fuzz_corpus': experiment_config['oss_fuzz_corpus'],
         'num_cpu_cores': experiment_config['runner_num_cpu_cores'],
         'cpuset': CPUSET,
+        'random_seed_corpus': experiment_config['random_seed_corpus'],
     }
 
     if not local_experiment:

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -31,6 +31,7 @@ git_hash: "git-hash"
 no_seeds: false
 no_dictionaries: false
 oss_fuzz_corpus: false
+random_seed_corpus: false
 description: "Test experiment"
 concurrent_builds: null
 runners_cpus: null

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -31,7 +31,7 @@ git_hash: "git-hash"
 no_seeds: false
 no_dictionaries: false
 oss_fuzz_corpus: false
-random_seed_corpus: false
+random_seed_corpus_dir: null
 description: "Test experiment"
 concurrent_builds: null
 runners_cpus: null

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -202,6 +202,7 @@ def test_copy_resources_to_bucket(tmp_path):
         'experiment': 'experiment',
         'benchmarks': ['libxslt_xpath'],
         'oss_fuzz_corpus': True,
+        'random_seed_corpus': False,
     }
     try:
         with mock.patch('common.filestore_utils.cp') as mocked_filestore_cp:

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -202,7 +202,7 @@ def test_copy_resources_to_bucket(tmp_path):
         'experiment': 'experiment',
         'benchmarks': ['libxslt_xpath'],
         'oss_fuzz_corpus': True,
-        'random_seed_corpus': False,
+        'random_seed_corpus_dir': None,
     }
     try:
         with mock.patch('common.filestore_utils.cp') as mocked_filestore_cp:

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -118,7 +118,7 @@ docker run \\
 -e NO_SEEDS=False \\
 -e NO_DICTIONARIES=False \\
 -e OSS_FUZZ_CORPUS=False \\
--e RANDOM_SEED_CORPUS=False \\
+-e RANDOM_SEED_CORPUS_DIR=None \\
 -e DOCKER_REGISTRY=gcr.io/fuzzbench -e CLOUD_PROJECT=fuzzbench -e CLOUD_COMPUTE_ZONE=us-central1-a \\
 -e EXPERIMENT_FILESTORE=gs://experiment-data \\
 -e REPORT_FILESTORE=gs://web-reports \\

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -118,6 +118,7 @@ docker run \\
 -e NO_SEEDS=False \\
 -e NO_DICTIONARIES=False \\
 -e OSS_FUZZ_CORPUS=False \\
+-e RANDOM_SEED_CORPUS=False \\
 -e DOCKER_REGISTRY=gcr.io/fuzzbench -e CLOUD_PROJECT=fuzzbench -e CLOUD_COMPUTE_ZONE=us-central1-a \\
 -e EXPERIMENT_FILESTORE=gs://experiment-data \\
 -e REPORT_FILESTORE=gs://web-reports \\


### PR DESCRIPTION
This PR adds an optional flag to enable user to set seed corpora for the experiment. There are two essential components that we need to modify 1.)[experiment/run_experiment.py](https://github.com/Practical-Formal-Methods/fuzzbench-public/compare/master...Practical-Formal-Methods:use_random_seeds?expand=1#diff-f29fa4fe4e55f233de1357ff219fd6df4fc408fcbdd0406f3fb5a022e11c670b) and 2.) [experiment/runner.py](https://github.com/Practical-Formal-Methods/fuzzbench-public/compare/master...Practical-Formal-Methods:use_random_seeds?expand=1#diff-477f82d2600187a036be84e9d61fdd8efee43640492e8d46759cc3d494aaeed4).  

The runner_experiment (`run_experiment.py`) basically validates the given seed corpus directory and feeds the zipped version of such directory to the fuzzing worker (`runner.py`).  The worker then unzips this directory and randomly pick single input as the initial seed and start the fuzzing campaign. 